### PR TITLE
Add admin tooling for editing comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Working with Pull Requests
+
+### Targeting a different base branch
+
+If you opened a pull request against the wrong base branch (for example, `main`) but would prefer it to merge into another branch such as `v1`, you can update it without recreating the PR:
+
+1. Open the pull request in your Git hosting provider (e.g., GitHub).
+2. Locate the base branch selector near the top of the page. On GitHub this appears as `base: <branch-name>`.
+3. Change the base from the current branch to `v1`.
+4. Review the comparison view that appears. If the new base introduces merge conflicts, resolve them locally and push the fixes to your feature branch.
+5. Once everything looks correct, save the change. The PR will now target `v1`.
+
+If you are still creating the PR, simply choose `v1` as the base branch in the pull request form before submitting.

--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,8 @@ import Helpful from './Components/Helpful'; // Import the HelpfulLinks component
 import NewAddressPage from './Components/Address/NewAddressPage';
 import VacancyStatusList from './Components/VacancyStatusList';
 import Review from './Components/Inspection/Review';
+import AdminDashboard from './Components/AdminDashboard';
+import AdminCommentEditor from './Components/AdminCommentEditor';
 
 function App() {
   return (
@@ -110,6 +112,8 @@ function MainApp() {
             <Route path="/helpful" element={<Helpful />} />
             <Route path="/new-address" element={<NewAddressPage />} />
             <Route path="/vacancy-statuses" element={<VacancyStatusList />} />
+            <Route path="/admin" element={<AdminDashboard />} />
+            <Route path="/admin/comments/:commentId/edit" element={<AdminCommentEditor />} />
             {/* Add more routes as needed */}
           </Routes>
         </Sidebar>

--- a/src/Components/AdminCommentEditor.js
+++ b/src/Components/AdminCommentEditor.js
@@ -1,0 +1,529 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+
+const EXCLUDED_KEYS = new Set([
+  'id',
+  'created_at',
+  'updated_at',
+  'deleted_at',
+  'user',
+  'photos',
+  'attachments',
+  'history',
+]);
+
+const LONG_TEXT_FIELDS = new Set(['content', 'internal_notes', 'admin_notes', 'follow_up_notes']);
+
+const formatLabel = (key) =>
+  key
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const deriveFields = (comment) => {
+  if (!comment) return [];
+  const fields = [];
+  for (const [key, value] of Object.entries(comment)) {
+    if (EXCLUDED_KEYS.has(key)) continue;
+    if (value === null) {
+      fields.push({ key, type: 'string' });
+      continue;
+    }
+    const valueType = typeof value;
+    if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
+      fields.push({ key, type: valueType });
+    }
+  }
+
+  const orderHint = [
+    'content',
+    'visibility',
+    'is_internal',
+    'is_flagged',
+    'requires_follow_up',
+    'follow_up_at',
+    'follow_up_user_id',
+    'address_id',
+    'unit_id',
+    'violation_id',
+    'contact_id',
+    'inspection_id',
+    'complaint_id',
+    'business_id',
+    'permit_id',
+    'license_id',
+    'user_id',
+  ];
+
+  const orderMap = new Map(orderHint.map((field, index) => [field, index]));
+  fields.sort((a, b) => {
+    const aRank = orderMap.has(a.key) ? orderMap.get(a.key) : orderHint.length + a.key.charCodeAt(0);
+    const bRank = orderMap.has(b.key) ? orderMap.get(b.key) : orderHint.length + b.key.charCodeAt(0);
+    if (aRank === bRank) {
+      return a.key.localeCompare(b.key);
+    }
+    return aRank - bRank;
+  });
+
+  return fields;
+};
+
+const formatDateTime = (value) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toLocaleString();
+};
+
+const AdminCommentEditor = () => {
+  const { commentId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [comment, setComment] = useState(null);
+  const [formValues, setFormValues] = useState({});
+  const [fields, setFields] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [status, setStatus] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [fileQueue, setFileQueue] = useState([]);
+  const [uploading, setUploading] = useState(false);
+  const [uploadStatus, setUploadStatus] = useState('');
+
+  const apiBase = process.env.REACT_APP_API_URL;
+
+  const loadComment = useCallback(async () => {
+    if (!commentId) return;
+    setLoading(true);
+    setError('');
+    setStatus('');
+    try {
+      const response = await fetch(`${apiBase}/comments/${commentId}`);
+      if (!response.ok) {
+        throw new Error('Failed to load comment details.');
+      }
+      const data = await response.json();
+      setComment(data);
+      const derived = deriveFields(data);
+      setFields(derived);
+      const initialValues = {};
+      derived.forEach(({ key, type }) => {
+        const value = data[key];
+        if (type === 'boolean') {
+          initialValues[key] = Boolean(value);
+        } else if (type === 'number') {
+          initialValues[key] = value ?? '';
+        } else {
+          initialValues[key] = value ?? '';
+        }
+      });
+      setFormValues(initialValues);
+    } catch (err) {
+      setError(err.message || 'Unable to load comment details.');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBase, commentId]);
+
+  useEffect(() => {
+    loadComment();
+  }, [loadComment]);
+
+  const handleValueChange = (key, type, value) => {
+    setFormValues((prev) => ({
+      ...prev,
+      [key]: type === 'number' && value === '' ? '' : value,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!comment) return;
+    setSaving(true);
+    setError('');
+    setStatus('');
+    setUploadStatus('');
+    try {
+      const payload = {};
+      fields.forEach(({ key, type }) => {
+        const originalValue = comment[key];
+        let nextValue = formValues[key];
+        if (type === 'number') {
+          nextValue = nextValue === '' || nextValue === null ? null : Number(nextValue);
+        } else if (type === 'boolean') {
+          nextValue = Boolean(nextValue);
+        } else if (typeof nextValue === 'string') {
+          nextValue = nextValue.trim().length ? nextValue : null;
+        } else if (typeof nextValue === 'undefined') {
+          nextValue = null;
+        }
+        const normalizedOriginal =
+          originalValue === null || typeof originalValue === 'undefined'
+            ? null
+            : type === 'number'
+            ? Number(originalValue)
+            : type === 'boolean'
+            ? Boolean(originalValue)
+            : String(originalValue);
+        const normalizedNext =
+          nextValue === null
+            ? null
+            : type === 'number'
+            ? Number(nextValue)
+            : type === 'boolean'
+            ? Boolean(nextValue)
+            : String(nextValue);
+        const changed = normalizedOriginal !== normalizedNext;
+        if (changed) {
+          payload[key] = nextValue;
+        }
+      });
+
+      if (Object.keys(payload).length === 0) {
+        setStatus('No changes detected.');
+        return;
+      }
+
+      const response = await fetch(`${apiBase}/comments/${commentId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        throw new Error('Failed to update the comment.');
+      }
+      const updated = await response.json();
+      setComment(updated);
+      const derived = deriveFields(updated);
+      setFields(derived);
+      const nextValues = {};
+      derived.forEach(({ key, type }) => {
+        const value = updated[key];
+        if (type === 'boolean') {
+          nextValues[key] = Boolean(value);
+        } else if (type === 'number') {
+          nextValues[key] = value ?? '';
+        } else {
+          nextValues[key] = value ?? '';
+        }
+      });
+      setFormValues(nextValues);
+      setStatus('Comment updated successfully.');
+    } catch (err) {
+      setError(err.message || 'Unable to update the comment.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm('Delete this comment? This action cannot be undone.')) {
+      return;
+    }
+    setDeleting(true);
+    setError('');
+    setStatus('');
+    setUploadStatus('');
+    try {
+      const response = await fetch(`${apiBase}/comments/${commentId}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        throw new Error('Failed to delete the comment.');
+      }
+      setStatus('Comment deleted.');
+      setTimeout(() => {
+        navigate('/admin?resource=comments');
+      }, 600);
+    } catch (err) {
+      setError(err.message || 'Unable to delete the comment.');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleFilesSelected = (event) => {
+    const picked = Array.from(event.target.files || []);
+    if (picked.length === 0) return;
+    setFileQueue((prev) => {
+      const next = [...prev];
+      picked.forEach((file) => {
+        if (!next.find((existing) => existing.name === file.name && existing.size === file.size && existing.lastModified === file.lastModified)) {
+          next.push(file);
+        }
+      });
+      return next;
+    });
+    event.target.value = '';
+  };
+
+  const handleUpload = async () => {
+    if (!fileQueue.length) return;
+    setUploading(true);
+    setUploadStatus('');
+    setError('');
+    try {
+      const formData = new FormData();
+      fileQueue.forEach((file) => formData.append('files', file));
+      const response = await fetch(`${apiBase}/comments/${commentId}/photos`, {
+        method: 'POST',
+        body: formData,
+      });
+      if (!response.ok) {
+        throw new Error('Failed to upload attachments.');
+      }
+      setUploadStatus('Attachments uploaded successfully.');
+      setFileQueue([]);
+      await loadComment();
+    } catch (err) {
+      setError(err.message || 'Unable to upload attachments.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const attachmentList = useMemo(() => {
+    const photos = (comment && (comment.photos || comment.attachments)) || [];
+    if (!Array.isArray(photos)) return [];
+    return photos;
+  }, [comment]);
+
+  if (!user || user.role !== 3) {
+    return (
+      <div className="max-w-3xl mx-auto mt-10 bg-white shadow rounded-lg p-8">
+        <h1 className="text-2xl font-semibold text-gray-800">Admin access required</h1>
+        <p className="mt-4 text-gray-600">You must be an administrator to edit comments.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Edit Comment</h1>
+          <p className="text-sm text-gray-600 mt-1">Adjust comment content, relationships, and metadata.</p>
+        </div>
+        <Link
+          to="/admin?resource=comments"
+          className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+        >
+          &larr; Back to admin dashboard
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="mt-8 rounded-md bg-white shadow p-6 text-gray-600">Loading comment...</div>
+      ) : error ? (
+        <div className="mt-6 rounded-md bg-red-50 p-4 text-red-700">{error}</div>
+      ) : comment ? (
+        <>
+          <div className="mt-6 rounded-lg bg-white shadow p-6">
+            <h2 className="text-lg font-medium text-gray-900">Comment overview</h2>
+            <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">Comment ID</dt>
+                <dd className="mt-1 text-sm text-gray-900">#{comment.id}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">Author</dt>
+                <dd className="mt-1 text-sm text-gray-900">
+                  {comment.user?.name || comment.user?.email || `User #${comment.user_id || '—'}`}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">Created</dt>
+                <dd className="mt-1 text-sm text-gray-900">{formatDateTime(comment.created_at)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">Last updated</dt>
+                <dd className="mt-1 text-sm text-gray-900">{formatDateTime(comment.updated_at)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">Target</dt>
+                <dd className="mt-1 text-sm text-gray-900">
+                  {[
+                    comment.address_id ? `Address #${comment.address_id}` : null,
+                    comment.unit_id ? `Unit #${comment.unit_id}` : null,
+                    comment.violation_id ? `Violation #${comment.violation_id}` : null,
+                    comment.contact_id ? `Contact #${comment.contact_id}` : null,
+                    comment.inspection_id ? `Inspection #${comment.inspection_id}` : null,
+                    comment.complaint_id ? `Complaint #${comment.complaint_id}` : null,
+                    comment.business_id ? `Business #${comment.business_id}` : null,
+                    comment.permit_id ? `Permit #${comment.permit_id}` : null,
+                    comment.license_id ? `License #${comment.license_id}` : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' · ') || '—'}
+                </dd>
+              </div>
+              {comment.commentable_type && (
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">Commentable type</dt>
+                  <dd className="mt-1 text-sm text-gray-900">{comment.commentable_type}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+          {status && (
+            <div className="rounded-md bg-green-50 p-4 text-green-700">{status}</div>
+          )}
+          {uploadStatus && !status && (
+            <div className="rounded-md bg-indigo-50 p-4 text-indigo-700">{uploadStatus}</div>
+          )}
+
+          <div className="rounded-lg bg-white shadow divide-y divide-gray-200">
+            {fields.length === 0 ? (
+              <div className="p-6 text-sm text-gray-500">No editable fields available for this comment.</div>
+            ) : (
+              fields.map(({ key, type }) => {
+                const value = formValues[key];
+                const label = formatLabel(key);
+                return (
+                  <div key={key} className="p-6">
+                    <label className="block text-sm font-medium text-gray-700" htmlFor={`field-${key}`}>
+                      {label}
+                    </label>
+                    {type === 'boolean' ? (
+                      <div className="mt-2 flex items-center">
+                        <input
+                          id={`field-${key}`}
+                          type="checkbox"
+                          checked={Boolean(value)}
+                          onChange={(event) => handleValueChange(key, type, event.target.checked)}
+                          className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                        />
+                        <span className="ml-2 text-sm text-gray-600">Enable {label.toLowerCase()}</span>
+                      </div>
+                    ) : type === 'number' ? (
+                      <input
+                        id={`field-${key}`}
+                        type="number"
+                        value={value === null ? '' : value}
+                        onChange={(event) => handleValueChange(key, type, event.target.value)}
+                        className="mt-2 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                      />
+                    ) : LONG_TEXT_FIELDS.has(key) || (typeof value === 'string' && value && value.length > 120) ? (
+                      <textarea
+                        id={`field-${key}`}
+                        value={value ?? ''}
+                        onChange={(event) => handleValueChange(key, type, event.target.value)}
+                        rows={6}
+                        className="mt-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                      />
+                    ) : (
+                      <input
+                        id={`field-${key}`}
+                        type="text"
+                        value={value ?? ''}
+                        onChange={(event) => handleValueChange(key, type, event.target.value)}
+                        className="mt-2 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                      />
+                    )}
+                    <p className="mt-1 text-xs text-gray-400">Field key: {key}</p>
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          {attachmentList.length > 0 && (
+            <div className="rounded-lg bg-white shadow p-6">
+              <h2 className="text-lg font-medium text-gray-900">Existing Attachments</h2>
+              <ul className="mt-4 space-y-2">
+                {attachmentList.map((file, index) => (
+                  <li key={file.id || file.url || index} className="text-sm text-indigo-600 truncate">
+                    <a
+                      href={file.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="hover:underline"
+                    >
+                      {file.filename || file.url || `Attachment ${index + 1}`}
+                    </a>
+                    {file.filesize && (
+                      <span className="ml-2 text-xs text-gray-500">{Math.round(file.filesize / 1024)} KB</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="rounded-lg bg-white shadow p-6">
+            <h2 className="text-lg font-medium text-gray-900">Upload Attachments</h2>
+            <p className="mt-1 text-sm text-gray-500">Attach additional documents or images to this comment.</p>
+            <div className="mt-4 flex flex-col sm:flex-row sm:items-center sm:space-x-4 space-y-3 sm:space-y-0">
+              <input
+                id="admin-comment-files"
+                type="file"
+                multiple
+                onChange={handleFilesSelected}
+                className="text-sm"
+              />
+              {fileQueue.length > 0 && (
+                <span className="text-sm text-gray-600">{fileQueue.length} file{fileQueue.length > 1 ? 's' : ''} selected</span>
+              )}
+              <button
+                type="button"
+                onClick={handleUpload}
+                disabled={uploading || fileQueue.length === 0}
+                className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {uploading ? 'Uploading…' : 'Upload'}
+              </button>
+              {fileQueue.length > 0 && (
+                <button
+                  type="button"
+                  className="text-sm text-gray-500 hover:text-gray-700"
+                  onClick={() => setFileQueue([])}
+                  disabled={uploading}
+                >
+                  Clear selection
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div className="flex gap-3">
+              <button
+                type="submit"
+                disabled={saving}
+                className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {saving ? 'Saving…' : 'Save changes'}
+              </button>
+              <button
+                type="button"
+                onClick={loadComment}
+                disabled={loading}
+                className="inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Refresh
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="inline-flex items-center rounded-md border border-transparent bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {deleting ? 'Deleting…' : 'Delete comment'}
+            </button>
+          </div>
+        </form>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+export default AdminCommentEditor;

--- a/src/Components/AdminDashboard.js
+++ b/src/Components/AdminDashboard.js
@@ -1,0 +1,472 @@
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+
+const RESOURCE_CONFIG = [
+  {
+    key: 'addresses',
+    label: 'Addresses',
+    listEndpoint: '/addresses/',
+    deleteEndpoint: (id) => `/addresses/${id}`,
+    viewRoute: (id) => `/address/${id}`,
+    fields: ['id', 'combadd', 'city', 'zip', 'status'],
+  },
+  {
+    key: 'contacts',
+    label: 'Contacts',
+    listEndpoint: '/contacts/',
+    deleteEndpoint: (id) => `/contacts/${id}`,
+    viewRoute: (id) => `/contacts/${id}`,
+    fields: ['id', 'name', 'email', 'phone'],
+  },
+  {
+    key: 'businesses',
+    label: 'Businesses',
+    listEndpoint: '/businesses/',
+    deleteEndpoint: (id) => `/businesses/${id}`,
+    viewRoute: (id) => `/business/${id}`,
+    fields: ['id', 'name', 'address.combadd', 'phone', 'email'],
+  },
+  {
+    key: 'violations',
+    label: 'Violations',
+    listEndpoint: '/violations/',
+    deleteEndpoint: (id) => `/violations/${id}`,
+    viewRoute: (id) => `/violation/${id}`,
+    fields: ['id', 'status', 'code.code', 'created_at'],
+  },
+  {
+    key: 'inspections',
+    label: 'Inspections',
+    listEndpoint: '/inspections/',
+    deleteEndpoint: (id) => `/inspections/${id}`,
+    viewRoute: (id) => `/inspection/${id}`,
+    fields: ['id', 'status', 'scheduled_for', 'address.combadd'],
+  },
+  {
+    key: 'permits',
+    label: 'Permits',
+    listEndpoint: '/permits/',
+    deleteEndpoint: (id) => `/permits/${id}`,
+    viewRoute: (id) => `/permit/${id}`,
+    fields: ['id', 'permit_number', 'status', 'address.combadd'],
+  },
+  {
+    key: 'licenses',
+    label: 'Licenses',
+    listEndpoint: '/licenses/',
+    deleteEndpoint: (id) => `/licenses/${id}`,
+    viewRoute: (id) => `/license/${id}`,
+    fields: ['id', 'license_number', 'status', 'business.name'],
+  },
+  {
+    key: 'complaints',
+    label: 'Complaints',
+    listEndpoint: '/complaints/',
+    deleteEndpoint: (id) => `/complaints/${id}`,
+    viewRoute: (id) => `/complaint/${id}`,
+    fields: ['id', 'type', 'status', 'address.combadd'],
+  },
+  {
+    key: 'comments',
+    label: 'Comments',
+    listEndpoint: '/comments/',
+    deleteEndpoint: (id) => `/comments/${id}`,
+    viewRoute: (id) => `/admin/comments/${id}/edit`,
+    fields: [
+      'id',
+      'content',
+      'user.name',
+      'address_id',
+      'unit_id',
+      'violation_id',
+      'contact_id',
+      'created_at',
+    ],
+  },
+  {
+    key: 'citations',
+    label: 'Citations',
+    listEndpoint: '/citations/',
+    deleteEndpoint: (id) => `/citations/${id}`,
+    viewRoute: (id) => `/citation/${id}`,
+    fields: ['id', 'citationid', 'status', 'deadline'],
+  },
+  {
+    key: 'codes',
+    label: 'Codes',
+    listEndpoint: '/codes/',
+    deleteEndpoint: (id) => `/codes/${id}`,
+    viewRoute: (id) => `/code/${id}`,
+    fields: ['id', 'code', 'description', 'section'],
+  },
+  {
+    key: 'users',
+    label: 'Users',
+    listEndpoint: '/users/',
+    deleteEndpoint: (id) => `/users/${id}`,
+    viewRoute: (id) => `/users/${id}`,
+    fields: ['id', 'name', 'email', 'role'],
+  },
+];
+
+const PAGE_SIZE = 20;
+
+const ROLE_LABELS = {
+  0: 'Guest',
+  1: 'ONS',
+  2: 'OAS',
+  3: 'Admin',
+};
+
+const normalizeValue = (value) => {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') return value;
+  if (value instanceof Date) return value.toLocaleString();
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : '—';
+  }
+  if (Array.isArray(value)) {
+    if (!value.length) return '—';
+    const preview = value
+      .map((item) => {
+        if (item && typeof item === 'object') {
+          if (item.name) return item.name;
+          if (item.title) return item.title;
+          if (item.combadd) return item.combadd;
+          if (item.id) return `#${item.id}`;
+          return JSON.stringify(item);
+        }
+        return item;
+      })
+      .join(', ');
+    return preview || '—';
+  }
+  if (typeof value === 'object') {
+    if (value.name) return value.name;
+    if (value.title) return value.title;
+    if (value.combadd) return value.combadd;
+    if (value.email) return value.email;
+    if (value.phone) return value.phone;
+    return JSON.stringify(value);
+  }
+  return value;
+};
+
+const getNestedValue = (item, path) => {
+  if (!path) return undefined;
+  return path.split('.').reduce((acc, key) => {
+    if (acc === null || acc === undefined) {
+      return undefined;
+    }
+    return acc[key];
+  }, item);
+};
+
+const resolveFields = (items, resource) => {
+  const configured = resource.fields || [];
+  const hasData = (field) =>
+    items.some((item) => {
+      const value = getNestedValue(item, field);
+      return value !== undefined && value !== null && value !== '';
+    });
+
+  let fields = configured.filter(hasData);
+
+  if (!fields.length && items.length) {
+    const firstItem = items[0];
+    fields = Object.keys(firstItem)
+      .filter((key) => typeof firstItem[key] !== 'object')
+      .slice(0, 4);
+
+    if (!fields.length) {
+      fields = Object.keys(firstItem).slice(0, 4);
+    }
+  }
+
+  return fields;
+};
+
+const AdminDashboard = () => {
+  const { user } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const defaultResourceKey = RESOURCE_CONFIG[0].key;
+  const [resourceKey, setResourceKey] = useState(() => {
+    const paramKey = searchParams.get('resource');
+    return RESOURCE_CONFIG.some((entry) => entry.key === paramKey) ? paramKey : defaultResourceKey;
+  });
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [page, setPage] = useState(1);
+  const [statusMessage, setStatusMessage] = useState('');
+
+  const resource = useMemo(
+    () => RESOURCE_CONFIG.find((entry) => entry.key === resourceKey) || RESOURCE_CONFIG[0],
+    [resourceKey]
+  );
+
+  const fetchItems = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    setStatusMessage('');
+    try {
+      const response = await fetch(`${process.env.REACT_APP_API_URL}${resource.listEndpoint}`);
+      if (!response.ok) {
+        throw new Error(`Failed to load ${resource.label.toLowerCase()}`);
+      }
+      const data = await response.json();
+      if (!Array.isArray(data)) {
+        setItems([]);
+        setError('Unexpected response format from the server.');
+      } else {
+        setItems(data);
+      }
+    } catch (err) {
+      setError(err.message || 'Unable to load data.');
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [resource.listEndpoint, resource.label]);
+
+  useEffect(() => {
+    const paramKey = searchParams.get('resource');
+    if (paramKey && RESOURCE_CONFIG.some((entry) => entry.key === paramKey) && paramKey !== resourceKey) {
+      setResourceKey(paramKey);
+    } else if (!paramKey && resourceKey !== defaultResourceKey) {
+      setResourceKey(defaultResourceKey);
+    }
+  }, [searchParams, resourceKey, defaultResourceKey]);
+
+  useEffect(() => {
+    fetchItems();
+    setPage(1);
+    setSearchTerm('');
+  }, [resourceKey, fetchItems]);
+
+  const handleResourceChange = useCallback(
+    (nextKey) => {
+      setResourceKey(nextKey);
+      const nextParams = new URLSearchParams(searchParams);
+      if (nextKey === defaultResourceKey) {
+        nextParams.delete('resource');
+      } else {
+        nextParams.set('resource', nextKey);
+      }
+      setSearchParams(nextParams, { replace: true });
+    },
+    [defaultResourceKey, searchParams, setSearchParams]
+  );
+
+  const filteredItems = useMemo(() => {
+    if (!searchTerm.trim()) return items;
+    const query = searchTerm.trim().toLowerCase();
+    return items.filter((item) => {
+      const values = resource.fields || Object.keys(item);
+      return values.some((field) => {
+        const value = getNestedValue(item, field);
+        if (value === undefined || value === null) return false;
+        return String(normalizeValue(value)).toLowerCase().includes(query);
+      });
+    });
+  }, [items, searchTerm, resource.fields]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const startIndex = (currentPage - 1) * PAGE_SIZE;
+  const currentItems = filteredItems.slice(startIndex, startIndex + PAGE_SIZE);
+
+  const fields = useMemo(() => resolveFields(currentItems, resource), [currentItems, resource]);
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Are you sure you want to delete this record? This action cannot be undone.')) {
+      return;
+    }
+    setStatusMessage('');
+    try {
+      const response = await fetch(`${process.env.REACT_APP_API_URL}${resource.deleteEndpoint(id)}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        throw new Error('Failed to delete the record.');
+      }
+      setItems((prev) => prev.filter((item) => item.id !== id));
+      setStatusMessage('Record deleted successfully.');
+    } catch (err) {
+      setStatusMessage(err.message || 'Unable to delete the record.');
+    }
+  };
+
+  if (!user || user.role !== 3) {
+    return (
+      <div className="max-w-4xl mx-auto mt-10 bg-white shadow rounded-lg p-8">
+        <h1 className="text-2xl font-semibold text-gray-800">Admin access required</h1>
+        <p className="mt-4 text-gray-600">
+          You must be an administrator to view and manage application data.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8">
+      <div className="sm:flex sm:items-center sm:justify-between">
+        <div className="sm:flex-auto">
+          <h1 className="text-base font-semibold leading-6 text-gray-900">Administration</h1>
+          <p className="mt-2 text-sm text-gray-700">
+            Review, edit, and delete objects across the platform. Use the resource selector to load different data sets.
+          </p>
+        </div>
+        <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+          <button
+            type="button"
+            onClick={fetchItems}
+            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="resource" className="block text-sm font-medium text-gray-700">
+            Resource
+          </label>
+          <select
+            id="resource"
+            value={resourceKey}
+            onChange={(event) => handleResourceChange(event.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          >
+            {RESOURCE_CONFIG.map((entry) => (
+              <option key={entry.key} value={entry.key}>
+                {entry.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="search" className="block text-sm font-medium text-gray-700">
+            Search
+          </label>
+          <input
+            id="search"
+            type="search"
+            value={searchTerm}
+            onChange={(event) => {
+              setPage(1);
+              setSearchTerm(event.target.value);
+            }}
+            placeholder={`Search ${resource.label.toLowerCase()}...`}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          />
+        </div>
+      </div>
+
+      {statusMessage && (
+        <div className="mt-4 rounded-md bg-indigo-50 p-4 text-sm text-indigo-700">
+          {statusMessage}
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4 rounded-md bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-6 overflow-hidden rounded-lg bg-white shadow">
+        <div className="overflow-x-auto">
+          {loading ? (
+            <div className="flex items-center justify-center py-16 text-gray-500">Loading {resource.label.toLowerCase()}...</div>
+          ) : currentItems.length ? (
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  {fields.map((field) => (
+                    <th
+                      key={field}
+                      scope="col"
+                      className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500"
+                    >
+                      {field.split('.').slice(-1)[0].replace(/_/g, ' ')}
+                    </th>
+                  ))}
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {currentItems.map((item) => (
+                  <tr key={item.id}>
+                    {fields.map((field) => {
+                      const value = normalizeValue(getNestedValue(item, field));
+                      return (
+                        <td key={field} className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                          {field === 'role' && typeof item.role === 'number'
+                            ? ROLE_LABELS[item.role] || item.role
+                            : value}
+                        </td>
+                      );
+                    })}
+                    <td className="whitespace-nowrap px-4 py-3 text-sm">
+                      <div className="flex items-center gap-3">
+                        <Link
+                          to={resource.viewRoute ? resource.viewRoute(item.id) : '#'}
+                          className="text-indigo-600 hover:text-indigo-900"
+                        >
+                          View & Edit
+                        </Link>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(item.id)}
+                          className="text-red-600 hover:text-red-800"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="flex items-center justify-center py-16 text-gray-500">
+              No {resource.label.toLowerCase()} found.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {!loading && currentItems.length > 0 && (
+        <div className="mt-4 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+            disabled={currentPage === 1}
+            className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <span className="text-sm text-gray-600">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+            disabled={currentPage === totalPages}
+            className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/src/Layouts/Sidebar.js
+++ b/src/Layouts/Sidebar.js
@@ -39,6 +39,7 @@ const navigation = [
   { name: 'Helpful Links', href: '/Helpful', icon: DocumentDuplicateIcon, current: false },
   { name: 'New Address', href: '/new-address', icon: BuildingOffice2Icon, current: false, roles: ['Admin'] },
   { name: 'Vacancy Statuses', href: '/vacancy-statuses', icon: BuildingOffice2Icon, current: false },
+  { name: 'Admin Dashboard', href: '/admin', icon: Cog6ToothIcon, current: false, roles: ['Admin'] },
 ];
 
 function classNames(...classes) {


### PR DESCRIPTION
## Summary
- add the comments resource to the admin dashboard with URL-synced selection and a link to an admin edit view
- create a dedicated AdminCommentEditor that surfaces comment metadata, dynamic form controls, attachment uploads, and delete actions for admins
- register the admin comment editor route so administrators can open the new tooling directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e44d6888448324abba0c86308e8f30